### PR TITLE
Revert "Deal with Mavericks changing some typedefs."

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -11,16 +11,6 @@ package sysv_mq
 #include <string.h>
 #include <sys/msg.h>
 
-#ifdef __APPLE__
-#include <Availability.h>
-#endif
-
-#ifdef __MAC_10_9
-unsigned long ulongOnMavericks(size_t size) { return (unsigned long)size; }
-#else
-size_t ulongOnMavericks(size_t size) { return (size_t)size; }
-#endif
-
 typedef struct _sysv_msg {
   long mtype;
   char mtext[];
@@ -70,7 +60,7 @@ func msgsnd(key int, message string, buffer *C.sysv_msg, maxSize int, mtype int,
 	msgSize := C.size_t(len(message))
 
 	buffer.mtype = C.long(mtype)
-	C.strncpy(C.get_string(buffer), cString, C.ulongOnMavericks(msgSize))
+	C.strncpy(C.get_string(buffer), cString, msgSize)
 
 	_, err := C.msgsnd(C.int(key), unsafe.Pointer(buffer), msgSize, C.int(flags))
 
@@ -138,7 +128,7 @@ func msgctl(key int, cmd int) (*C.struct_msqid_ds, error) {
 // zero-length arrays that Go does not support
 func allocateBuffer(strSize int) (*C.sysv_msg, error) {
 	// The +1 here is because strcpy in msgsnd copies the terminating null byte
-	bufferSize := C.ulongOnMavericks(C.size_t(strSize)) + C.ulongOnMavericks(C.size_t(unsafe.Sizeof(C.long(1))))
+	bufferSize := C.size_t(strSize) + C.size_t(unsafe.Sizeof(C.long(1)))
 	buffer := (*C.sysv_msg)(C.malloc(bufferSize))
 
 	if buffer == nil {


### PR DESCRIPTION
This reverts commit 26fe22bdf0216166a9a7e52d798e916a073fbf14.

If this breaks things for you, you compiled Go with clang on OS X 10.9,
and you should reinstall it using `brew install go --source`.

Review @Sirupsen 
