### PR TITLE
Implement MQ.Destroy()

### DIFF
--- a/mq.go
+++ b/mq.go
@@ -60,13 +60,13 @@ func NewMessageQueue(config *QueueConfig) (*MessageQueue, error) {
 	err := mq.connect()
 
 	if err != nil {
-		return mq, errors.New("Error connecting to queue: " + err.Error())
+		return mq, err
 	}
 
 	mq.buffer, err = allocateBuffer(mq.config.MaxSize)
 
 	if err != nil {
-		return mq, errors.New("Error allocating buffer for queue: " + err.Error())
+		return mq, err
 	}
 	runtime.SetFinalizer(mq, func(mq *MessageQueue) {
 		mq.Close()

--- a/mq.go
+++ b/mq.go
@@ -104,23 +104,15 @@ func (mq *MessageQueue) ReceiveString(msgType int, flags int) (string, int, erro
 	}
 }
 
-// DEPRECATED
-// Sends a string message to the queue of the type passed as the second argument.
-func (mq *MessageQueue) Send(message string, msgType int) error {
-	return mq.SendString(message, msgType, 0)
-}
-
-// DEPRECATED
-// Receive a string message with the type specified by the integer argument.
-// Pass 0 to retrieve the message at the top of the queue, regardless of type.
-func (mq *MessageQueue) Receive(msgType int) (string, error) {
-	str, _, err := mq.ReceiveString(msgType, 0)
-	return str, err
-}
-
 // Get statistics about the message queue.
 func (mq *MessageQueue) Stat() (*QueueStats, error) {
 	return ipcStat(mq.id)
+}
+
+// Get statistics about the message queue.
+func (mq *MessageQueue) Destroy() error {
+	defer mq.Close()
+	return ipcDestroy(mq.id)
 }
 
 // Number of messages currently in the queue.

--- a/mq_test.go
+++ b/mq_test.go
@@ -2,6 +2,7 @@ package sysv_mq
 
 import (
 	"fmt"
+	"syscall"
 	"testing"
 )
 
@@ -130,6 +131,29 @@ func Test_QueueClose(t *testing.T) {
 	mq.Close()
 	mq.Close()
 	mq.Close()
+}
+
+func TestQueueDestroy(t *testing.T) {
+	mq := SampleMessageQueue(t)
+
+	if mq2, err := NewMessageQueue(&QueueConfig{Key: SysVIPCKey}); err != nil {
+		t.Fatal(err)
+	} else {
+		mq2.Close()
+	}
+
+	mq.Destroy()
+
+	mq3, err := NewMessageQueue(&QueueConfig{Key: SysVIPCKey})
+	switch err {
+	case nil:
+		mq3.Close()
+		t.Fatal("Expected opening of MQ to fail after it has been destroyed, but it succeeded.")
+	case syscall.ENOENT:
+		t.Log("Failed to open MQ as expected")
+	default:
+		t.Fatal(err)
+	}
 }
 
 func Test_QueueSize(t *testing.T) {

--- a/wrapper.go
+++ b/wrapper.go
@@ -123,6 +123,12 @@ func freeBuffer(buffer *C.sysv_msg) {
 	C.free(unsafe.Pointer(buffer))
 }
 
+// Wraps msgctl(key, IPC_RMID).
+func ipcDestroy(key int) error {
+	_, err := msgctl(key, IPC_RMID)
+	return err
+}
+
 // Wraps msgctl(key, IPC_STAT).
 func ipcStat(key int) (*QueueStats, error) {
 	info, err := msgctl(key, IPC_STAT)


### PR DESCRIPTION
Wrap `msgctl(ket, IPC_RMID)` so we can destroy queues. This is useful for testing purposes.
See http://man7.org/linux/man-pages/man2/msgctl.2.html for more info.

@Sirupsen @Shopify/kafka for review