### PR TITLE
Fix 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
-go: 
+go:
   - 1.1
   - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
   - release
 
 script:

--- a/mq.go
+++ b/mq.go
@@ -4,7 +4,7 @@ package sysv_mq
 #include <stdlib.h>
 typedef struct _sysv_msg {
   long mtype;
-  char mtext[];
+  char mtext[1];
 } sysv_msg;
 */
 import "C"


### PR DESCRIPTION
As of Go 1.5, "When a C struct ends with a zero-sized field, but the struct
itself is not zero-sized, Go code can no longer refer to the zero-sized field.
Any such references will have to be rewritten" (#12). This is from the following
upstream change https://go-review.googlesource.com/#/c/12864/ which says

    In order to fix issue #9401 the compiler was changed to add a padding
    byte to any non-empty Go struct that ends in a zero-sized field.  That
    causes the Go version of such a C struct to have a different size than
    the C struct, which can considerable confusion.  Change cgo so that it
    discards any such zero-sized fields, so that the Go and C structs are
    the same size.

Also for reference, the SysV API says the following:

    The msgp argument is a pointer to a caller-defined structure of the
    following general form:

        struct msgbuf {
            long mtype;       /* message type, must be > 0 */
            char mtext[1];    /* message data */
        };

    The mtext field is an array (or other structure) whose size is
    specified by msgsz, a nonnegative integer value.

Our mtext field is runtime-user-defined via configuration, so we had been
defining our struct to include `char mtext[]` and then allocating mmory of the
appropriate size manually (sizeof(long) + bufferLength, basically). However,
while empty arrays are convention for variable-length inline buffers, this is C - you
can do whatever the hell you like with enough (void*)s in play.

In fact though, we don't need any - because we are already manually constructing
the size of the memory to allocate without reference to sizeof(mtext) or
sizeof(sysv_msg), we can simply define mtext as `char mtext[1]` (which has a
defined size to make Go happy) and then keep doing exactly what we were doing in
terms of manually allocating/sizing memory. For us, `mtext` could be literally
any type as long as that type has a defined non-zero length and requires no
alignment; `char[1]` is the least misleading, however.

So the actual change is tiny and trivial; the work here was proving and
understanding why it works, fixing a few comments, and writing this commit
message.

@Sirupsen @burke @wvanbergen @andremedeiros @kvs 

Fixes #12 