### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/mq.go
+++ b/mq.go
@@ -103,12 +103,12 @@ func (mq *MessageQueue) ReceiveString(msgType int, flags int) (string, int, erro
 	}
 }
 
-// Get statistics about the message queue.
+// Stat gets statistics about the message queue.
 func (mq *MessageQueue) Stat() (*QueueStats, error) {
 	return ipcStat(mq.id)
 }
 
-// Get statistics about the message queue.
+// Destroy gets statistics about the message queue.
 func (mq *MessageQueue) Destroy() error {
 	defer mq.Close()
 	return ipcDestroy(mq.id)


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!